### PR TITLE
Refactor WeatherAPI.tsx to add Weather interface and update useState type

### DIFF
--- a/components/weatherAPI.tsx
+++ b/components/weatherAPI.tsx
@@ -1,9 +1,33 @@
 // WeatherAPI.tsx
 import React, { useState } from 'react';
 
+interface Weather {
+    current: {
+      uv: number;
+      humidity: number;
+      precip_mm: number;
+      temp_c: number;
+      condition: {
+        text: string;
+        icon: string;
+      };
+    };
+    forecast: {
+      forecastday: {
+        hour: Array<{
+          temp_c: number;
+          condition: {
+            icon: string;
+          };
+          time: string;
+        }>;
+      }[];
+    };
+  }
+
 const WeatherAPI = () => {
     const [city, setCity] = useState('');
-    const [weather, setWeather] = useState(null);
+    const [weather, setWeather] = useState<Weather | null>(null);
 
     const handleCityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setCity(event.target.value);


### PR DESCRIPTION
Reason why I did not use React FC and instead opted to just use a const variable:

WeatherAPI component doesn't use children, doesn't need generics, and doesn't have default props, so it's perfectly fine to type it as a regular function. If you want to use React.FC

This fixes the vercel deployment and makes it useable and gets rid of the errors.
